### PR TITLE
Fix the conflicts between contract identifiers and generated identifiers

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -271,7 +271,7 @@ class _ContractGeneration {
       _assignFunction(b.statements, function, index);
 
       b
-        ..addExpression(literalList(params).assignFinal('params'))
+        ..addExpression(literalList(params).assignFinal('\$params'))
         ..addExpression(refer('read')
             .call([argFunction, argParams, refer('atBlock')])
             .awaited
@@ -288,14 +288,14 @@ class _ContractGeneration {
       argCredentials,
       refer('transaction'),
       refer('function'),
-      refer('params'),
+      refer('\$params'),
     ]);
 
     return Block((b) {
       _assignFunction(b.statements, function, index);
 
       b
-        ..addExpression(literalList(params).assignFinal('params'))
+        ..addExpression(literalList(params).assignFinal('\$params'))
         ..addExpression(funWrite.returned);
     });
   }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -77,7 +77,7 @@ final argCredentials = refer('credentials');
 
 final argContract = refer('self');
 final argFunction = refer('function');
-final argParams = refer('params');
+final argParams = refer('\$params');
 
 final argPrivateKey = refer('privateKey');
 

--- a/test/data.dart
+++ b/test/data.dart
@@ -70,13 +70,13 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, '2783b284'));
-    final params = [
+    final $params = [
       first,
       second,
     ];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
     return Retrieve3(response);
@@ -178,10 +178,10 @@ class Contract extends _i1.GeneratedContract {
   Future<GiveMeHello> giveMeHello({_i1.BlockNum? atBlock}) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, '1c1657ea'));
-    final params = [];
+    final $params = [];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
     return GiveMeHello(response);
@@ -193,10 +193,10 @@ class Contract extends _i1.GeneratedContract {
   Future<BigInt> retrieve({_i1.BlockNum? atBlock}) async {
     final function = self.abi.functions[1];
     assert(checkSignature(function, '2e64cec1'));
-    final params = [];
+    final $params = [];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
     return (response[0] as BigInt);
@@ -212,12 +212,12 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[2];
     assert(checkSignature(function, '6057361d'));
-    final params = [num];
+    final $params = [num];
     return write(
       credentials,
       transaction,
       function,
-      params,
+      $params,
     );
   }
 }
@@ -290,10 +290,10 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, '7dbfb5dc'));
-    final params = [$param0];
+    final $params = [$param0];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
     return (response[0] as BigInt);
@@ -383,10 +383,10 @@ class Contract extends _i1.GeneratedContract {
   Future<List<List<List<String>>>> test({_i1.BlockNum? atBlock}) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, 'f8a8fd6d'));
-    final params = [];
+    final $params = [];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
     return (response[0] as List<dynamic>)
@@ -524,7 +524,7 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, '42842e0e'));
-    final params = [
+    final $params = [
       _from,
       _to,
       _tokenId,
@@ -533,7 +533,7 @@ class Contract extends _i1.GeneratedContract {
       credentials,
       transaction,
       function,
-      params,
+      $params,
     );
   }
 
@@ -550,7 +550,7 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[1];
     assert(checkSignature(function, 'b88d4fde'));
-    final params = [
+    final $params = [
       _from,
       _to,
       _tokenId,
@@ -560,7 +560,7 @@ class Contract extends _i1.GeneratedContract {
       credentials,
       transaction,
       function,
-      params,
+      $params,
     );
   }
 }
@@ -626,14 +626,14 @@ class Contract extends _i1.GeneratedContract {
   }) async {
     final function = self.abi.functions[0];
     assert(checkSignature(function, '2ecff2f6'));
-    final params = [
+    final $params = [
       tokenId,
       serviceType,
       serviceId,
     ];
     final response = await read(
       function,
-      params,
+      $params,
       atBlock,
     );
   }
@@ -802,4 +802,64 @@ class Transfer$2 {
   final _i1.FilterEvent event;
 }
 ''',
+  r'''
+[
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "params",
+          "type": "uint256"
+        }
+      ],
+      "name": "paramsFunc",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]''': r'''
+// Generated code, do not modify. Run `build_runner build` to re-generate!
+// @dart=2.12
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:web3dart/web3dart.dart' as _i1;
+
+final _contractAbi = _i1.ContractAbi.fromJson(
+  '[{"inputs":[{"internalType":"uint256","name":"params","type":"uint256"}],"name":"paramsFunc","outputs":[],"stateMutability":"nonpayable","type":"function"}]',
+  'Contract',
+);
+
+class Contract extends _i1.GeneratedContract {
+  Contract({
+    required _i1.EthereumAddress address,
+    required _i1.Web3Client client,
+    int? chainId,
+  }) : super(
+          _i1.DeployedContract(
+            _contractAbi,
+            address,
+          ),
+          client,
+          chainId,
+        );
+
+  /// The optional [transaction] parameter can be used to override parameters
+  /// like the gas price, nonce and max gas. The `data` and `to` fields will be
+  /// set by the contract.
+  Future<String> paramsFunc(
+    BigInt params, {
+    required _i1.Credentials credentials,
+    _i1.Transaction? transaction,
+  }) async {
+    final function = self.abi.functions[0];
+    assert(checkSignature(function, 'f6163fb4'));
+    final $params = [params];
+    return write(
+      credentials,
+      transaction,
+      function,
+      $params,
+    );
+  }
+}
+'''
 };


### PR DESCRIPTION
# Motivation

There are contracts whose identifiers conflict with the identifiers of the generated classes. For example, Uniswap v3-periphery [QuoterV2](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/QuoterV2.sol) contains functions with an argument named `params` that conflicts with a variable of the generated class.

# Problems

I see several _levels_ of this problem:

- [x] conflict caused by the `params` argument of the specified contract;
- [ ] conflicts between identifiers that are keywords in Dart and are valid identifiers in Solidity (like `async`, `assert`, `class`, etc);
- [ ] conflict between contract identifiers and any other identifiers in the generated classes (like `read` and `write` functions identifier, `self` variable identifier of GeneratedContract class, etc);

# Possible Solutions

I wrote a simple fix for the conflict of identifiers named `params` (by replacing the generated variable with `$params`) and a test for this case. But it won't work if the identifier in the contract is `$params` (valid identifiers in Solidity).

For cases of conflicts based on the use of Dart keywords, it would be possible to use dictionary renaming using the template `$keyword` or `_keyword`.

For cases of conflicts between contact identifiers and generated identifiers, dynamic identifier generation could be used for use in generated classes where possible.