### PR TITLE
Replace `pub` with `dart run` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ dart pub add web3dart_builders --dev
 
 # Usage
 ```shell
-pub run build_runner build
+dart pub run build_runner build
 ```
 
 or
 ```shell
-pub run build_runner watch
+dart pub run build_runner watch
 ```
 
 # Test


### PR DESCRIPTION
`pub` was replaced `dart run` in the previous Dart versions.